### PR TITLE
build: add basic build information

### DIFF
--- a/dvc_dat/__init__.py
+++ b/dvc_dat/__init__.py
@@ -1,8 +1,9 @@
+__version__ = "1.0.04"
+DAT_VERSION = f"{__version__} (2024-05-30)"
 
 from .dvc_dat_config import DatConfig, _DAT_MOUNT_COMMANDS
 from .do_fn import DoManager, do_argv
 
-DAT_VERSION = "1.0.04 (2024-05-30)"
 dat_config = DatConfig()
 do = DoManager()  # not available during load of do_fn
 
@@ -16,5 +17,14 @@ do.mount(module=dat_tools, at="dt")
 do.mount(value=dat_tools.cmd_list, at="dt.list")
 do.mount(value=dat_tools.cmd_list, at="dat_tools.list")
 
-__all__ = ["DAT_VERSION", "dat_config", "Dat", "DatContainer", "DatConfig", "DoManager",
-           "do", "do_argv", "dat_tools"]
+__all__ = [
+    "DAT_VERSION",
+    "dat_config",
+    "Dat",
+    "DatContainer",
+    "DatConfig",
+    "DoManager",
+    "do",
+    "do_argv",
+    "dat_tools",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dvc_dat"
-version = "0.0.1"
 dependencies = [
     "pandas",
     "pyyaml",
@@ -12,6 +11,10 @@ dependencies = [
 requires-python = ">= 3.8"
 keywords = ["dvc"]
 readme = "README.md"
+dynamic = ["version"]
 
 [tool.setuptools]
 packages = ["dvc_dat"]
+
+[tool.setuptools.dynamic]
+version = {attr = "dvc_dat.__init__.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dvc_dat"
+version = "0.0.1"
+dependencies = [
+    "pandas",
+    "pyyaml",
+]
+requires-python = ">= 3.8"
+keywords = ["dvc"]
+readme = "README.md"
+
+[tool.setuptools]
+packages = ["dvc_dat"]


### PR DESCRIPTION
Add a basic `pyproject.toml` setup to make the project pip installable. I'm assuming a minimum python version of 3.8, so feel free to change that.